### PR TITLE
Fixes based on workshop run-through

### DIFF
--- a/terraform-config/aws-devops-core/README.md
+++ b/terraform-config/aws-devops-core/README.md
@@ -1,2 +1,2 @@
 # AWS DevOps Core
-This repository contains the core DevOps infrastructure which currently includes the Pipelines used for Terraform module validation and deployment, as well as the CodeCommit repositories the configurations are stored in.
+This repository contains the core DevOps infrastructure which currently includes the Pipelines used for Terraform module validation and deployment, as well as the S3 buckets used to simulate our Git repositories (via [git-remote-s3](https://github.com/awslabs/git-remote-s3)) where the configurations are stored.

--- a/terraform-config/modules/README.md
+++ b/terraform-config/modules/README.md
@@ -1,2 +1,2 @@
 # About this directory
-This directory is meant to house a collection of local Terraform modules. For now this just contains the `module-aws-tf-cicd` module which can dynamically create AWS CodeCommit Repositories, AWS CodePipelines (and related necessary services) on AWS.
+This directory is meant to house a collection of local Terraform modules. For now this just contains the `module-aws-tf-cicd` module which can dynamically create all the necessary services to setup our Terraform CI/CD Pipelines on AWS.

--- a/workshop-solution/aws-devops-core/README.md
+++ b/workshop-solution/aws-devops-core/README.md
@@ -1,2 +1,2 @@
 # AWS DevOps Core
-This repository contains the core DevOps infrastructure which currently includes the Pipelines used for Terraform module validation and deployment, as well as the CodeCommit repositories the configurations are stored in.
+This repository contains the core DevOps infrastructure which currently includes the Pipelines used for Terraform module validation and deployment, as well as the S3 buckets used to simulate our Git repositories (via [git-remote-s3](https://github.com/awslabs/git-remote-s3)) where the configurations are stored.

--- a/workshop-solution/aws-devops-core/main.tf
+++ b/workshop-solution/aws-devops-core/main.tf
@@ -347,7 +347,7 @@ module "module-aws-tf-cicd" {
               # Store the output of this stage as 'build_tf_test_output_artifacts' in the connected Artifacts S3 Bucket
               output_artifacts = ["build_tf_apply_output_artifacts"]
 
-              run_order = 4
+              run_order = 5
             },
           ]
         },

--- a/workshop-solution/example-production-workload/tests/main.tftest.hcl
+++ b/workshop-solution/example-production-workload/tests/main.tftest.hcl
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 # - End-to-end Tests -
-run "e2e_test" {
+run "integration_test" {
   command = apply
 
   # Using global variables defined above since additional variables block is not defined here

--- a/workshop-solution/modules/README.md
+++ b/workshop-solution/modules/README.md
@@ -1,2 +1,2 @@
 # About this directory
-This directory is meant to house a collection of local Terraform modules. For now this just contains the `module-aws-tf-cicd` module which can dynamically create AWS CodeCommit Repositories, AWS CodePipelines (and related necessary services) on AWS.
+This directory is meant to house a collection of local Terraform modules. For now this just contains the `module-aws-tf-cicd` module which can dynamically create all the necessary services to setup our Terraform CI/CD Pipelines on AWS.

--- a/workshop-solution/modules/module-aws-tf-cicd/git-s3.tf
+++ b/workshop-solution/modules/module-aws-tf-cicd/git-s3.tf
@@ -1,4 +1,4 @@
-# Instructions: Dynamically create AWS CodeCommit Repos
+# Instructions: Dynamically create git repositories with git-remote-s3
 
 resource "random_string" "git_remote_s3_buckets" {
   for_each = var.git_remote_s3_buckets == null ? {} : var.git_remote_s3_buckets

--- a/workshop-solution/modules/module-aws-tf-cicd/tests/main.tftest.hcl
+++ b/workshop-solution/modules/module-aws-tf-cicd/tests/main.tftest.hcl
@@ -305,7 +305,7 @@ run "input_validation" {
 }
 
 # - End-to-end Tests -
-run "e2e_test" {
+run "integration_test" {
   command = apply
 
   # Using global variables defined above since additional variables block is not defined here


### PR DESCRIPTION
- Replace CodeCommit references with S3 bucket terminology in README files
- Rename e2e_test to integration_test in Terraform test files for clarity
- Update module descriptions to reflect git-remote-s3 usage instead of CodeCommit
- Fix pipeline run_order from 4 to 5 in main.tf configuration
- Clarify that S3 buckets simulate Git repositories via git-remote-s3 tool